### PR TITLE
Fix relativepath tar context path

### DIFF
--- a/examples/build-path-context/build.go
+++ b/examples/build-path-context/build.go
@@ -18,7 +18,6 @@ func main() {
 	var dockerCli *client.Client
 
 	imageDefinitionPath := filepath.Join(".", "files")
-
 	registry := "registry"
 	namespace := "namespace"
 	imageName := strings.Join([]string{registry, namespace, "ubuntu"}, "/")
@@ -34,7 +33,7 @@ func main() {
 
 	dockerBuildOptions := &build.DockerBuildOptions{
 		ImageName:          imageName,
-		Dockerfile:         "Dockerfile",
+		Dockerfile:         filepath.Join("Dockerfile"),
 		Tags:               []string{strings.Join([]string{imageName, "tag1"}, ":")},
 		DockerBuildContext: dockerBuildContext,
 	}

--- a/examples/build-path-context/files/Dockerfile
+++ b/examples/build-path-context/files/Dockerfile
@@ -1,5 +1,3 @@
 FROM ubuntu
 
-RUN apt-get update \
-    && apt-get upgrade -y
-
+COPY etc/config/file.cfg /tmp

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// DefaultDockerfile is the default filename for Dockerfile
-	DefaultDockerfile = "Dockerfile"
+	DefaultDockerfile string = "Dockerfile"
 )
 
 // DockerBuilderCmd


### PR DESCRIPTION
target relative path is not solved proverly when any subpath coincides to basedir.